### PR TITLE
Add timeout for pop3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ options.password|`true`|
 options.host|`false`|
 options.port|`true`|Default to `110`
 options.tls|`true`|Default to `false`
+options.timeout|`true`|Default to `undefined`
 
 * basic
 
@@ -80,5 +81,5 @@ Beyound that, Error may own two property attached by pop3.
 
 property|comment
 ---|---
-`err.eventName`|event name comes from `socket.on`. Include `error`, `close` and `end`
+`err.eventName`|event name comes from `socket.on`. Include `error`, `close`, `timeout` and `end`
 `err.command`|which command causes the error. For example, `PASS example`

--- a/src/Command.js
+++ b/src/Command.js
@@ -10,8 +10,9 @@ class Pop3Command extends Pop3Connection {
     host,
     port,
     tls,
+    timeout,
   }) {
-    super({ host, port, tls });
+    super({ host, port, tls, timeout });
     this.user = user;
     this.password = password;
     this._PASSInfo = '';

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -64,8 +64,12 @@ class Pop3Connection extends EventEmitter {
           const err = new Error('timeout');
           err.eventName = 'timeout';
           reject(err);
-          this.emit('end', err);
-          this.emit('error', err);
+          if (this.listeners('end').length) {
+            this.emit('end', err);
+          }
+          if (this.listeners('error').length) {
+            this.emit('error', err);
+          }
           this._socket.end();
           this._socket = null;
         });

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -65,6 +65,7 @@ class Pop3Connection extends EventEmitter {
           err.eventName = 'timeout';
           reject(err);
           this.emit('end', err);
+          this.emit('error', err);
           this._socket.end();
           this._socket = null;
         });


### PR DESCRIPTION
给`socket`加了`timeout`选项，当触发`timeout`事件时，`pop3Command`会触发`reject`，返回一个`err.eventName`为`timeout`的`err`。并会自动触发`socket.end()`。