### PR TITLE
fix: reverse POP3 dot-stuffing in multi-line responses (RFC 1939 §3)

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -13,8 +13,57 @@ export function stream2String (stream) {
       buffer = Buffer.concat([buffer, _buffer], len);
     });
     stream.on('error', (err) => reject(err));
-    stream.on('end', () => resolve(buffer.toString()));
+    stream.on('end', () => {
+      // Reverse POP3 byte-stuffing (RFC 1939 Section 3):
+      // The server prepends a '.' to any line starting with '.' to avoid
+      // confusion with the multi-line terminator. The client must remove it.
+      const result = dotUnstuff(buffer);
+      resolve(result.toString());
+    });
   });
+}
+
+/**
+ * Reverse POP3 dot-stuffing (RFC 1939 Section 3).
+ *
+ * Any line beginning with ".." has the extra leading "." removed.
+ *
+ * @param {Buffer} buffer
+ * @returns {Buffer}
+ */
+function dotUnstuff (buffer) {
+  const dot = 0x2E;
+  const cr = 0x0D;
+  const lf = 0x0A;
+  const chunks = [];
+  let start = 0;
+
+  // Check first line (no preceding CRLF)
+  if (buffer.length >= 2 && buffer[0] === dot && buffer[1] === dot) {
+    start = 1;
+  }
+
+  for (let i = start; i < buffer.length - 3; i++) {
+    if (
+      buffer[i] === cr &&
+      buffer[i + 1] === lf &&
+      buffer[i + 2] === dot &&
+      buffer[i + 3] === dot
+    ) {
+      // Include up to and including \r\n.
+      chunks.push(buffer.subarray(start, i + 3));
+      // Skip the extra dot
+      start = i + 4;
+      i = start - 1;
+    }
+  }
+
+  if (chunks.length === 0 && start === 0) {
+    return buffer;
+  }
+
+  chunks.push(buffer.subarray(start));
+  return Buffer.concat(chunks);
 }
 
 /**


### PR DESCRIPTION
## Problem

[RFC 1939 Section 3](https://www.rfc-editor.org/rfc/rfc1939#section-3) requires that POP3 clients reverse byte-stuffing on multi-line responses:

> If any line of the multi-line response begins with the termination octet, the line is "byte-stuffed" by pre-pending the termination octet to that line of the response.

The client must remove this extra `.` when receiving. Currently, `stream2String` does not do this.

## Impact

When any line in an email body starts with `.` (common in HTML emails with URLs like `.com/example` or CSS selectors like `.content`), the POP3 server dot-stuffs it to `..com/example`. Since the client doesn't reverse this, the extra `.` stays in the message content. This corrupts the message body and breaks DKIM body hash verification.

## Fix

Adds a `dotUnstuff()` function in `helper.js` that operates on the raw `Buffer` before string conversion in `stream2String()`. It replaces `\r\n..` sequences with `\r\n.` and handles the edge case of the first line starting with `..`.

## Verification

Tested against a SmarterMail POP3 server with a message containing two dot-stuffed lines in HTML content. Before the fix, the DKIM body hash mismatched. After applying `dotUnstuff()`, the computed body hash matches the expected `bh=` value from the DKIM-Signature header exactly.